### PR TITLE
Move uninstall of generic mapper into setup function

### DIFF
--- a/src/scripts/coffeemud-gui/RoomEvent.lua
+++ b/src/scripts/coffeemud-gui/RoomEvent.lua
@@ -62,11 +62,6 @@ just noticed outside of room.info, what is room.enter="the tridone"?
 
 --]]
 
-uninstallPackage("generic_mapper")
---TODO: When I first added the uninstallPackage line, it crashed Mudlet.
---I had exported to a package and then imported it to other profile and added this line.
---No problem next time.
---Experiment some with it and see if I can repeat crash.
 --Also this section I should split off and put the code in the parent folder code block.  See how to structure that later.
 mudlet = mudlet or {}
 mudlet.mapper_script = true

--- a/src/scripts/coffeemud-gui/SetupGUI.lua
+++ b/src/scripts/coffeemud-gui/SetupGUI.lua
@@ -5,6 +5,8 @@ It duplicates code, but I wanted to leave the other part untouched as much as I 
 -Tim
 --]]
 
+uninstallPackage("generic_mapper")
+
 
 GUI.Icon1:echo("Look")
 GUI.Icon2:echo("Score")


### PR DESCRIPTION
Generic mapper script should uninstall itself properly as of update that I submitted which they accepted on March 24 and was included in release of 4.12.